### PR TITLE
Conversion Block tweaks: homepage hero shot w/ scroll tilt, new founder quote on white card

### DIFF
--- a/components/cta/ConversionBlock.tsx
+++ b/components/cta/ConversionBlock.tsx
@@ -299,7 +299,8 @@ export function ConversionBlock({
               background: "#FAFAF9",
               border: "1px solid #E5E7EB",
               borderRadius: 20,
-              padding: "clamp(28px, 4.5vw, 56px)",
+              padding:
+                "clamp(28px, 4.5vw, 56px) clamp(28px, 4.5vw, 56px) clamp(20px, 3vw, 32px)",
               display: "flex",
               flexWrap: "wrap",
               alignItems: "center",
@@ -397,11 +398,12 @@ export function ConversionBlock({
             </div>
 
             <div
+              className="quote-row"
               style={{
                 flex: "1 1 100%",
                 minWidth: 0,
                 borderTop: "1px solid #E5E7EB",
-                paddingTop: 28,
+                paddingTop: 20,
                 display: "flex",
                 justifyContent: "center",
               }}
@@ -410,21 +412,21 @@ export function ConversionBlock({
                 <p
                   style={{
                     margin: 0,
-                    fontSize: 16,
-                    lineHeight: 1.65,
-                    color: "#4B5563",
+                    fontSize: 14.5,
+                    lineHeight: 1.6,
+                    color: "#6B7280",
                   }}
                 >
-                  &ldquo;Over my career, I&apos;ve generated leads that became
-                  $6M+ in booked and paid keynotes. I&apos;ve simplified
-                  everything I know into one platform.&rdquo;
+                  &ldquo;I&apos;ve spent nearly a decade generating leads for
+                  individual speakers and bureaus. SpeakerDrive is everything I
+                  learned, simplified into one platform.&rdquo;
                 </p>
                 <div
                   style={{
                     display: "flex",
                     alignItems: "center",
-                    gap: 12,
-                    marginTop: 16,
+                    gap: 11,
+                    marginTop: 12,
                   }}
                 >
                   {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -432,8 +434,8 @@ export function ConversionBlock({
                     src="/austin_benton_head.png"
                     alt="Austin Benton"
                     style={{
-                      width: 44,
-                      height: 44,
+                      width: 40,
+                      height: 40,
                       borderRadius: "50%",
                       objectFit: "cover",
                       display: "block",
@@ -443,7 +445,7 @@ export function ConversionBlock({
                   <div style={{ display: "grid", gap: 3 }}>
                     <span
                       style={{
-                        fontSize: 14,
+                        fontSize: 13.5,
                         fontWeight: 700,
                         color: "#111827",
                         lineHeight: 1.2,
@@ -453,12 +455,21 @@ export function ConversionBlock({
                     </span>
                     <span
                       style={{
-                        fontSize: 13,
+                        fontSize: 12.5,
                         color: "#6B7280",
                         lineHeight: 1.2,
                       }}
                     >
                       Founder, SpeakerDrive
+                    </span>
+                    <span
+                      style={{
+                        fontSize: 12.5,
+                        color: "#6B7280",
+                        lineHeight: 1.2,
+                      }}
+                    >
+                      $6M+ in booked and paid keynotes generated
                     </span>
                     <a
                       className="li-link"
@@ -469,7 +480,7 @@ export function ConversionBlock({
                         display: "inline-flex",
                         alignItems: "center",
                         gap: 5,
-                        fontSize: 13,
+                        fontSize: 12.5,
                         fontWeight: 500,
                         color: "#0A66C2",
                         textDecoration: "none",

--- a/components/cta/ConversionBlock.tsx
+++ b/components/cta/ConversionBlock.tsx
@@ -397,13 +397,18 @@ export function ConversionBlock({
               </motion.div>
             </div>
 
+            {/* White card for contrast against the stone panel (Austin's pick;
+                revert this block to a borderTop hairline for the quiet look) */}
             <div
               className="quote-row"
               style={{
                 flex: "1 1 100%",
                 minWidth: 0,
-                borderTop: "1px solid #E5E7EB",
-                paddingTop: 20,
+                background: "#ffffff",
+                border: "1px solid #E5E7EB",
+                borderRadius: 12,
+                padding: "18px 24px",
+                marginTop: -12,
                 display: "flex",
                 justifyContent: "center",
               }}

--- a/components/cta/ConversionBlock.tsx
+++ b/components/cta/ConversionBlock.tsx
@@ -13,6 +13,12 @@
 // Render inline, never in an iframe — the sticky bar pins to the viewport.
 
 import { useEffect, useRef, useState } from "react";
+import {
+  motion,
+  useReducedMotion,
+  useScroll,
+  useTransform,
+} from "framer-motion";
 import { CtaButton } from "./CtaSection";
 
 // $99 × 12 — keep in sync with the "How much does it cost?" FAQ answer.
@@ -146,9 +152,23 @@ export function ConversionBlock({
 }) {
   const heroCtaRef = useRef<HTMLDivElement>(null);
   const roiRef = useRef<HTMLElement>(null);
+  const heroShotRef = useRef<HTMLDivElement>(null);
   const [fee, setFee] = useState(10000);
   const [showSticky, setShowSticky] = useState(false);
   const [dismissed, setDismissed] = useState(false);
+
+  // Same tilt-up-on-scroll as the homepage hero shot (Hero.tsx), retargeted
+  // to this panel: leans back 35° entering the viewport, upright by center.
+  const prefersReducedMotion = useReducedMotion();
+  const { scrollYProgress } = useScroll({
+    target: heroShotRef,
+    offset: ["start end", "end center"],
+  });
+  const rotateX = useTransform(
+    scrollYProgress,
+    [0, 1],
+    prefersReducedMotion ? [0, 0] : [35, 0],
+  );
 
   // Same slug cleanup the design's setUtmCampaign() applied.
   const slug =
@@ -348,20 +368,32 @@ export function ConversionBlock({
               </div>
             </div>
 
-            <div style={{ flex: "11 1 400px", minWidth: 0 }}>
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
-                src="/Dashboard-mh.png"
-                alt="The SpeakerDrive dashboard — speaking opportunities with verified contact info"
+            <div
+              ref={heroShotRef}
+              style={{ flex: "11 1 400px", minWidth: 0, perspective: 1000 }}
+            >
+              <motion.div
                 style={{
-                  display: "block",
-                  width: "100%",
-                  height: "auto",
-                  border: "1px solid rgba(0,0,0,0.08)",
-                  borderRadius: 12,
-                  boxShadow: "0 4px 24px rgba(0,0,0,0.08)",
+                  rotateX,
+                  transformOrigin: "center bottom",
+                  willChange: "transform",
+                  backfaceVisibility: "hidden",
                 }}
-              />
+              >
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src="/new_hero_image.png"
+                  alt="SpeakerDrive dashboard overview"
+                  style={{
+                    display: "block",
+                    width: "100%",
+                    height: "auto",
+                    border: "1px solid rgba(0,0,0,0.08)",
+                    borderRadius: 12,
+                    boxShadow: "0 4px 24px rgba(0,0,0,0.08)",
+                  }}
+                />
+              </motion.div>
             </div>
 
             <div


### PR DESCRIPTION
Three tweaks to the ConversionBlock per Austin:

1. **Hero panel image** — now the homepage hero shot (`new_hero_image.png`) with the homepage's tilt-up-on-scroll effect (framer-motion rotateX 35°→0°, flat under reduced motion).
2. **Founder quote** — new copy ("nearly a decade generating leads…"), byline gains "$6M+ in booked and paid keynotes generated", text stepped down a size, tighter padding below.
3. **White card** — the quote row sits on a white card inside the stone panel for contrast. Kept as a standalone commit (9716e11) for a one-step revert if the quiet hairline treatment wins.

Merging with rebase (not squash) to preserve per-tweak revertability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)